### PR TITLE
Update tyama_atcoderautumnfestK_validator2_fork.cpp

### DIFF
--- a/atcoder/tyama_atcoderautumnfestK_validator2_fork.cpp
+++ b/atcoder/tyama_atcoderautumnfestK_validator2_fork.cpp
@@ -67,6 +67,11 @@ int main(int argc, char **argv){
 		free(args);
 		return 0;
 	}
+	close(fd_in[0]);
+	close(fd_in[1]);
+	close(fd_out[0]);
+	close(fd_out[1]);
+	
 	int st1,st2;
 	waitpid(pid1,&st1,WUNTRACED);
 	waitpid(pid2,&st2,WUNTRACED);


### PR DESCRIPTION
validatorとprogramがランタイムエラーになった場合に、親プロセスがパイプが生きているので入力待ちになってしまう。
親プロセスでもパイプを閉じてEOFにさせるように変更。
